### PR TITLE
chore: add multi-OS checks + stack listing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  static-analysis:
+  tests:
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: ["ubuntu-20.04", "macos-10.15", "macos-11"]
 
-    name: Static Analysis
+    name: Run Tests
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -49,3 +49,12 @@ jobs:
 
       - name: Validate Stacks
         run: terramate run -- terraform validate
+
+  done:
+    name: Static Analysis
+    runs-on: ubuntu-20.04
+    needs: tests
+
+    steps:
+      - name: Done
+        run: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,13 @@ on:
 
 jobs:
   static-analysis:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-20.04", "macos-10.15", "macos-11"]
+
     name: Static Analysis
     steps:
       - name: Checkout
@@ -34,6 +40,9 @@ jobs:
 
       - name: Check Formatting
         run: terraform fmt -recursive -check -no-color
+
+      - name: List all Stacks
+        run: terramate list
 
       - name: Initialize Stacks
         run: terramate run -- terraform init

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # terramate-example-code-generation
 
+![CI Status](https://github.com/mineiros-io/terramate-example-code-generation/actions/workflows/ci.yml/badge.svg)
+[![Join Slack](https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack)](https://mineiros.io/slack)
+
 This project shows an example file/dir structure you can use with
 [Terramate](https://github.com/mineiros-io/terramate) to keep your Terraform
 code DRY.


### PR DESCRIPTION
Just to confirm that basic terramate commands are working also on macos (one possible bug report came from macos env). Also added stack listing to the CI, just to be sure it is working on the example. Also added some badges on the README.